### PR TITLE
Communicate widiget options through a JSON object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-* Allow the component to be more customisable (#6)
+* Allow the component to be more customisable (#6, #8)
 * Add documentation around testing (#7)
 
 ## [0.2.0] - 2023-07-17

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ Check out the Home controller in the [dummy app](spec/dummy/app/controllers/home
 
 ## Customising
 
-There are [myriad options](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations) that the widget can take, however so far we only support:
+There are [myriad options](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations) that the widget can take.  You can pass any of these options in to the component as arguments. e.g.
 
 * language (default to `I18n.locale` or `en`)
-* theme (default to `auto`)
-* size (default to `normal`)
+* theme
+* size
 
-I'm sure more will be added in future.  You can also add HTML attributes through the `attrs` parameter, e.g. `class`, `id`, etc.
+The options should be exactly as shown in the docs, i.e. with dashes rather than the more usual underscores encountered in Ruby.  You can also add HTML attributes through the `attrs` parameter, e.g. `class`, `id`, etc.
 
 To make use of these options, add them to the `new` call when rendering.
 

--- a/app/components/rpi_turnstile/turnstile_component.rb
+++ b/app/components/rpi_turnstile/turnstile_component.rb
@@ -13,11 +13,10 @@ module RpiTurnstile
       classes += Array(attrs[:class])
 
       data = { controller: 'rpi-turnstile--turnstile',
-               'rpi-turnstile--turnstile-target': 'container',
-               'rpi-turnstile--turnstile-language-value': I18n.locale || :en,
-               'rpi-turnstile--turnstile-sitekey-value': sitekey }
+               'rpi-turnstile--turnstile-target': 'container' }
 
-      data.merge!(kwargs.transform_keys { |k| "rpi-turnstile--turnstile-#{k}-value" })
+      options = kwargs.merge(language: I18n.locale || :en, sitekey: sitekey)
+      data['rpi-turnstile--turnstile-options-value'] = options.to_json
 
       @attrs = attrs.merge(class: classes, data: data)
     end

--- a/app/javascript/controllers/rpi_turnstile/turnstile_controller.js
+++ b/app/javascript/controllers/rpi_turnstile/turnstile_controller.js
@@ -2,12 +2,7 @@ import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
   static targets = ['container']
-  static values = {
-    sitekey: String,
-    theme: { type: String, default: "auto" },
-    language: { type: String, default: "en-GB" },
-    size: { type: String, default: "normal" }
-  }
+  static values = { options: Object }
 
   static sourceUrl = 'https://challenges.cloudflare.com/turnstile/v0/api.js'
   static callbackFunctionName = '__turnstileLoadedCallback'
@@ -32,7 +27,7 @@ export default class extends Controller {
   }
 
   connect () {
-    if (!this.hasSitekeyValue) return
+    if (!this.hasOptionsValue) return
 
     // This call waits for the promise returned by loadTurnstile to resolve
     // before trying to call render().
@@ -43,12 +38,7 @@ export default class extends Controller {
 
   render () {
     // See https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations
-    window.turnstile.render(this.containerTarget, {
-      language: this.languageValue,
-      sitekey: this.sitekeyValue,
-      size: this.sizeValue,
-      theme: this.themeValue
-    })
+    window.turnstile.render(this.containerTarget, this.optionsValue)
   }
 
   // This returns a promise that resolves when the loading has completed, or

--- a/spec/components/rpi_turnstile/turnstile_component_spec.rb
+++ b/spec/components/rpi_turnstile/turnstile_component_spec.rb
@@ -20,8 +20,10 @@ RSpec.describe RpiTurnstile::TurnstileComponent, type: :component do
 
   context 'when sitekey is set' do
     let(:sitekey) { 'abc' }
+    let(:options) { { language: :en, sitekey: sitekey } }
+    let(:encoded_opts) { options.to_json }
 
-    it { is_expected.to have_css("div.rpi-turnstile[data-controller='rpi-turnstile--turnstile'][data-rpi-turnstile--turnstile-target='container'][data-rpi-turnstile--turnstile-sitekey-value='#{sitekey}']") }
+    it { is_expected.to have_css("div.rpi-turnstile[data-controller='rpi-turnstile--turnstile'][data-rpi-turnstile--turnstile-target='container'][data-rpi-turnstile--turnstile-options-value='#{encoded_opts}']") }
 
     context 'when a class is set' do
       let(:attrs) { { class: 'foo' } }
@@ -37,8 +39,9 @@ RSpec.describe RpiTurnstile::TurnstileComponent, type: :component do
 
     context 'when another option is set' do
       let(:component) { described_class.new(foo: :bar, attrs: {}) }
+      let(:options) { { foo: :bar, language: :en, sitekey: sitekey } }
 
-      it { is_expected.to have_css("div.rpi-turnstile[data-rpi-turnstile--turnstile-foo-value='bar']") }
+      it { is_expected.to have_css("div.rpi-turnstile[data-rpi-turnstile--turnstile-options-value='#{encoded_opts}']") }
     end
   end
 end


### PR DESCRIPTION
This allows all options permitted by Cloudflare to be sent through in a JSON object, so we don't have to hard-code them all