### PR TITLE
Add importmap-rails as a gem dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+* Add importmap-rails as a gem dependency (#12)
+
 ## [0.3.0] - 2023-07-18
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     rpi_turnstile (0.3.0)
       faraday (~> 2.0)
+      importmap-rails
       rails (~> 7.0)
       sprockets-rails (~> 3.4)
       stimulus-rails (~> 1.2)

--- a/rpi_turnstile.gemspec
+++ b/rpi_turnstile.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.7'
 
   spec.add_dependency 'faraday', '~> 2.0'
+  spec.add_dependency 'importmap-rails'
   spec.add_dependency 'rails', '~> 7.0'
   spec.add_dependency 'sprockets-rails', '~> 3.4'
   spec.add_dependency 'stimulus-rails', '~> 1.2'


### PR DESCRIPTION
Installing the gem on a repo that didn't already use `importmap-rails` failed. This adds `importmap-rails` as a gem dependency