### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.4.0] - 2024-06-10
+
 ### Changed
 * Support for Ruby 2.7, 3.0, and 3.1 has been dropped. The minimum supported Ruby version is now 3.2. (#15)
 
@@ -42,7 +44,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Initial release
 
-[unreleased]: https://github.com/RaspberryPiFoundation/rpi-turnstile/compare/v0.3.1...HEAD
+[unreleased]: https://github.com/RaspberryPiFoundation/rpi-turnstile/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/RaspberryPiFoundation/rpi-turnstile/compare/v0.4.0
 [0.3.1]: https://github.com/RaspberryPiFoundation/rpi-turnstile/releases/tag/v0.3.1
 [0.3.0]: https://github.com/RaspberryPiFoundation/rpi-turnstile/releases/tag/v0.3.0
 [0.2.0]: https://github.com/RaspberryPiFoundation/rpi-turnstile/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Initial release
 
 [unreleased]: https://github.com/RaspberryPiFoundation/rpi-turnstile/compare/v0.4.0...HEAD
-[0.4.0]: https://github.com/RaspberryPiFoundation/rpi-turnstile/compare/v0.4.0
+[0.4.0]: https://github.com/RaspberryPiFoundation/rpi-turnstile/releases/tag/v0.4.0
 [0.3.1]: https://github.com/RaspberryPiFoundation/rpi-turnstile/releases/tag/v0.3.1
 [0.3.0]: https://github.com/RaspberryPiFoundation/rpi-turnstile/releases/tag/v0.3.0
 [0.2.0]: https://github.com/RaspberryPiFoundation/rpi-turnstile/releases/tag/v0.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rpi_turnstile (0.3.1)
+    rpi_turnstile (0.4.0)
       faraday (~> 2.0)
       importmap-rails
       rails (~> 7.0)

--- a/lib/rpi_turnstile/version.rb
+++ b/lib/rpi_turnstile/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RpiTurnstile
-  VERSION = '0.3.1'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
## Changed
* Support for Ruby 2.7, 3.0, and 3.1 has been dropped. The minimum supported Ruby version is  3.2. (#15)

## Fixed
* Update GitHub Actions workflows to use latest upload/download artifact actions (#15)
* Removed unnecessary `require` statements which break Rails 7.1+ (#14)