### PR TITLE
Update Turnstile JS controller to work multiple times on a page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 * Fix double rendering of the Turnstile widget when used with Turbo (#28)
+* Allow more than one Turnstile widget to be rendered on the same page (#30)
 
 ## [0.4.0] - 2024-06-10
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
 gem 'importmap-rails'
-gem 'puma'
+gem 'puma', '>= 6.4'
 gem 'sprockets-rails'
 gem 'stimulus-rails'
 gem 'turbo-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,5 @@ group :test do
   gem 'rspec-rails'
   gem 'selenium-webdriver'
   gem 'simplecov', require: false
-  gem 'webdrivers'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    nio4r (2.5.9)
+    nio4r (2.7.5)
     nokogiri (1.19.0-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.19.0-aarch64-linux-musl)
@@ -192,7 +192,7 @@ GEM
       racc
     prism (1.7.0)
     public_suffix (5.0.3)
-    puma (6.3.0)
+    puma (8.0.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.7)
@@ -362,7 +362,7 @@ DEPENDENCIES
   dotenv-rails
   importmap-rails
   openssl (~> 3.0)
-  puma
+  puma (>= 6.4)
   rpi_turnstile!
   rspec
   rspec-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,10 +328,6 @@ GEM
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -376,7 +372,6 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   turbo-rails
-  webdrivers
   webmock
 
 BUNDLED WITH

--- a/app/javascript/controllers/rpi_turnstile/turnstile_controller.js
+++ b/app/javascript/controllers/rpi_turnstile/turnstile_controller.js
@@ -7,32 +7,20 @@ export default class extends Controller {
   static sourceUrl = 'https://challenges.cloudflare.com/turnstile/v0/api.js'
   static callbackFunctionName = '__turnstileLoadedCallback'
 
-  loadingState = undefined
-  loadingPromise = {
-    resolve: () => {},
-    reject: () => {}
-  }
+  // Shared across all instances so that multiple widgets on the same page
+  // only ever inject one script tag and all resolve together.
+  static loadingState = typeof window.turnstile !== 'undefined' ? 'ready' : 'unloaded'
+  static pendingResolvers = []
+  static pendingRejectors = []
+
   widgetId = undefined
-
-  initialize () {
-    this.loadingState = typeof window.turnstile !== 'undefined' ? 'ready' : 'unloaded'
-
-    // This defines a global function that can be called by Turnstile once it
-    // has been loaded and ready.  The callbackFunctionName name is used in the
-    // URL of the script in the loadTurnstile() function.
-    window[this.constructor.callbackFunctionName] = () => {
-      this.loadingPromise.resolve()
-      this.loadingState = 'ready'
-      delete window[this.constructor.callbackFunctionName]
-    }
-  }
 
   connect () {
     if (!this.hasOptionsValue) return
 
     // This call waits for the promise returned by loadTurnstile to resolve
     // before trying to call render().
-    this.loadTurnstile()
+    this.constructor.loadTurnstile()
       .then(() => { this.render() })
       .catch((e) => console.log(e))
   }
@@ -52,37 +40,46 @@ export default class extends Controller {
     this.widgetId = window.turnstile.render(this.containerTarget, this.optionsValue)
   }
 
-  // This returns a promise that resolves when the loading has completed, or
-  // rejects if an error is raised during loading.
-  loadTurnstile () {
+  // Static so that all instances share a single script load. Returns a promise
+  // that resolves when Turnstile is ready, or rejects if the script fails to load.
+  static loadTurnstile () {
+    if (this.loadingState === 'ready') {
+      return Promise.resolve()
+    }
+
     if (this.loadingState === 'unloaded') {
       this.loadingState = 'loading'
 
+      // This defines a global function that Turnstile calls once it is ready.
+      // The name is embedded in the script URL via the onload parameter.
       // See https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#explicitly-render-the-turnstile-widget
-      const url = `${this.constructor.sourceUrl}?onload=${this.constructor.callbackFunctionName}&render=explicit`
+      window[this.callbackFunctionName] = () => {
+        this.loadingState = 'ready'
+        delete window[this.callbackFunctionName]
+        this.pendingResolvers.splice(0).forEach(resolve => resolve())
+        this.pendingRejectors.splice(0)
+      }
+
+      const url = `${this.sourceUrl}?onload=${this.callbackFunctionName}&render=explicit`
       const script = document.createElement('script')
       script.src = url
       script.async = true
       script.defer = true
 
       script.addEventListener('error', () => {
-        this.loadingPromise.reject('Failed to load Turnstile.')
-        delete window[this.constructor.callbackFunctionName]
+        this.loadingState = 'unloaded'
+        delete window[this.callbackFunctionName]
+        this.pendingRejectors.splice(0).forEach(reject => reject('Failed to load Turnstile.'))
+        this.pendingResolvers.splice(0)
       })
 
       document.head.appendChild(script)
     }
 
-    // Return a promise that we can resolve when the callback function is
-    // called by the Turnstile JS when it is ready.
+    // Loading is already in progress — queue this caller alongside any others.
     return new Promise((resolve, reject) => {
-      this.loadingPromise = { resolve, reject }
-
-      // If turnstile is already defined, resolve immediately.
-      if (this.loadingState === 'ready') {
-        resolve()
-        delete window[this.constructor.callbackFunctionName]
-      }
+      this.pendingResolvers.push(resolve)
+      this.pendingRejectors.push(reject)
     })
   }
 }

--- a/spec/dummy/app/controllers/home_controller.rb
+++ b/spec/dummy/app/controllers/home_controller.rb
@@ -4,6 +4,9 @@ class HomeController < ApplicationController
   def show
   end
 
+  def multiple
+  end
+
   def submit
     notice = rpi_turnstile_verified? ? "✅ Turnstile verification passed." : "❌ Turnstile verification failed."
 

--- a/spec/dummy/app/views/home/multiple.html.erb
+++ b/spec/dummy/app/views/home/multiple.html.erb
@@ -1,0 +1,13 @@
+<h1>Multiple Turnstile widgets</h1>
+
+<h2>First widget</h2>
+<%= form_with do |form| %>
+  <%= render RpiTurnstile::TurnstileComponent.new %>
+  <%= form.submit 'Submit widget 1' %>
+<% end %>
+
+<h2>Second widget</h2>
+<%= form_with do |form| %>
+  <%= render RpiTurnstile::TurnstileComponent.new %>
+  <%= form.submit 'Submit widget 2' %>
+<% end %>

--- a/spec/dummy/app/views/home/show.html.erb
+++ b/spec/dummy/app/views/home/show.html.erb
@@ -1,10 +1,15 @@
+<h1>Turnstile test page</h1>
+
 <% flash.each do |type, msg| %>
   <div>
     <%= msg %>
   </div>
 <% end %>
 
-<a href="/<%= SecureRandom.uuid %>">Go to random page</a>
+<p>
+<a href="/<%= SecureRandom.uuid %>">Go to random page</a><br/>
+<a href="/multiple">Go to page with multiple turnstiles</a>
+</p>
 
 <%= form_with url: "/#{SecureRandom.uuid}" do |form| %>
   <%= render RpiTurnstile::TurnstileComponent.new %>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "home#show"
 
+  # Multiple widgets on the same page, to test script-deduplication behaviour.
+  get '/multiple', to: 'home#multiple'
+
   # Allows another route, to test Turbo navigation.
   get "/*p", to: "home#show"
   post '/*p', to: "home#submit"

--- a/spec/dummy/spec/system/multiple_widgets_spec.rb
+++ b/spec/dummy/spec/system/multiple_widgets_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe '/multiple' do
       # loadTurnstile(). The shared static loadingState means only the first
       # call injects a <script>; subsequent callers just queue a pending promise.
       # We verify the outcome by counting script tags with the Turnstile URL.
-      have_css('script[src*="challenges.cloudflare.com/turnstile"]', count: 1)
+      expect(page).to have_css('script[src*="challenges.cloudflare.com/turnstile"]', count: 1, visible: false)
     end
   end
 end

--- a/spec/dummy/spec/system/multiple_widgets_spec.rb
+++ b/spec/dummy/spec/system/multiple_widgets_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe '/multiple' do
+  # Cloudflare Turnstile always-pass visible test sitekey.
+  let(:sitekey) { '1x00000000000000000000AA' }
+
+  context 'with two widgets on the same page', :js do
+    before do
+      stub_const('RpiTurnstile::Api::SITEKEY', sitekey)
+      visit '/multiple'
+    end
+
+    it 'renders both widget containers' do
+      expect(page).to have_css('[data-controller="rpi-turnstile--turnstile"]', count: 2)
+    end
+
+    it 'only injects a single Turnstile script tag' do
+      # Both controllers connect synchronously on page load and both call
+      # loadTurnstile(). The shared static loadingState means only the first
+      # call injects a <script>; subsequent callers just queue a pending promise.
+      # We verify the outcome by counting script tags with the Turnstile URL.
+      script_count = page.evaluate_script(
+        "document.querySelectorAll('script[src*=\"challenges.cloudflare.com/turnstile\"]').length"
+      )
+      expect(script_count).to eq 1
+    end
+  end
+end

--- a/spec/dummy/spec/system/multiple_widgets_spec.rb
+++ b/spec/dummy/spec/system/multiple_widgets_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe '/multiple' do
     end
 
     it 'renders both widget containers' do
-      expect(page).to have_css('[data-controller="rpi-turnstile--turnstile"]', count: 2)
+      expect(page).to have_css('div[data-controller="rpi-turnstile--turnstile"] > div', count: 2)
     end
 
     it 'only injects a single Turnstile script tag' do
@@ -21,10 +21,7 @@ RSpec.describe '/multiple' do
       # loadTurnstile(). The shared static loadingState means only the first
       # call injects a <script>; subsequent callers just queue a pending promise.
       # We verify the outcome by counting script tags with the Turnstile URL.
-      script_count = page.evaluate_script(
-        "document.querySelectorAll('script[src*=\"challenges.cloudflare.com/turnstile\"]').length"
-      )
-      expect(script_count).to eq 1
+      have_css('script[src*="challenges.cloudflare.com/turnstile"]', count: 1)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -83,8 +83,8 @@ RSpec.configure do |config|
     end
 
     # We need to allow net connect at this stage to allow WebDrivers to update
-    WebMock.allow_net_connect!
-    Webdrivers::Geckodriver.update
+    # WebMock.allow_net_connect!
+    # Webdrivers::Geckodriver.update
     WebMock.disable_net_connect!(allow_localhost: true, allow: [Capybara.server_host])
 
     driven_by ENV.fetch('CI', nil).present? ? :selenium_headless : :selenium, using: :firefox

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,9 +82,6 @@ RSpec.configure do |config|
       next
     end
 
-    # We need to allow net connect at this stage to allow WebDrivers to update
-    # WebMock.allow_net_connect!
-    # Webdrivers::Geckodriver.update
     WebMock.disable_net_connect!(allow_localhost: true, allow: [Capybara.server_host])
 
     driven_by ENV.fetch('CI', nil).present? ? :selenium_headless : :selenium, using: :firefox


### PR DESCRIPTION
## Changes in this PR

Reviewed the controller against the [Cloudflare Turnstile docs](https://developers.cloudflare.com/turnstile/llms-full.txt) and identified two bugs, both fixed here.

### Bug 1: Script load errors left `loadingState` stuck at `'loading'`

The `error` event handler on the injected `<script>` tag rejected the promise but never reset `loadingState`. Any subsequent `connect()` call (e.g. after a Turbo navigation back to the page) would create a promise that never resolves — the widget would be permanently broken after a transient network failure.

**Fix:** reset `loadingState = 'unloaded'` in the error handler so loading can be retried.

### Bug 2: Multiple widgets on the same page broke each other

The original implementation used instance-level `loadingState` and `loadingPromise`, with a shared static `callbackFunctionName`. With two controller instances on the same page:

1. Each `initialize()` overwrote `window.__turnstileLoadedCallback` with a closure over *its own* `loadingPromise` — only the **last** instance's callback survived.
2. Each `connect()` independently saw `loadingState === 'unloaded'` (it was per-instance) and injected its **own** `<script>` tag.
3. When the first script fired the callback, only the last-registered controller's promise resolved. The second script fired but the callback had already been deleted. The first controller's promise **never resolved** and its widget never rendered.

**Fix:** make the loading mechanism fully static — `loadingState`, `pendingResolvers`, and `pendingRejectors` are now class-level. Only one script tag is ever injected regardless of how many controller instances exist on the page, and all pending promises resolve together when Turnstile is ready. The `initialize()` lifecycle hook is no longer needed.