### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-05-13
 
 ### Fixed
 * Fix double rendering of the Turnstile widget when used with Turbo (#28)
@@ -48,7 +48,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Initial release
 
-[unreleased]: https://github.com/RaspberryPiFoundation/rpi-turnstile/compare/v0.4.0...HEAD
+[unreleased]: https://github.com/RaspberryPiFoundation/rpi-turnstile/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/RaspberryPiFoundation/rpi-turnstile/releases/tag/v0.5.0
 [0.4.0]: https://github.com/RaspberryPiFoundation/rpi-turnstile/releases/tag/v0.4.0
 [0.3.1]: https://github.com/RaspberryPiFoundation/rpi-turnstile/releases/tag/v0.3.1
 [0.3.0]: https://github.com/RaspberryPiFoundation/rpi-turnstile/releases/tag/v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.5.0] - 2026-05-13
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rpi_turnstile (0.4.0)
+    rpi_turnstile (0.5.0)
       faraday (~> 2.0)
       importmap-rails
       rails (~> 7.0)

--- a/lib/rpi_turnstile/version.rb
+++ b/lib/rpi_turnstile/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RpiTurnstile
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end


### PR DESCRIPTION
### Fixed
* Fix double rendering of the Turnstile widget when used with Turbo (#28)
* Allow more than one Turnstile widget to be rendered on the same page (#30)